### PR TITLE
Update with DeskThing functions, typesafety for reqs, and better clock handling

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -63,7 +63,8 @@ const start = async () => {
   };
 
   // We run a timer on the server, as a fallback for when the client-side app is backgrounded
-  setInterval(async function () {
+  // Uses the deskthing server's background task loop so that it can be cancelled when the app is paused or killed 
+  DeskThing.addBackgroundTaskLoop(async () => {
     if (timeLeftSec && !isPaused) {
       timeLeftSec = timeLeftSec - 1;
       hasTimerStarted = true;
@@ -102,7 +103,7 @@ const start = async () => {
         }
       }
     }
-  }, 1000);
+  }, 1000)
 
   DeskThing.on("timeLeftSec" as IncomingEvent, async (data) => {
     timeLeftSec = data.payload;

--- a/src/components/DeskThingBridge.tsx
+++ b/src/components/DeskThingBridge.tsx
@@ -1,7 +1,7 @@
-import { DeskThing, SocketData } from "deskthing-client";
+import { DeskThing } from "deskthing-client";
 import { coerceSettings, requirePomodoroContext } from "../util";
 import { useEffect, useState } from "react";
-import type { PomodoroSettings, TimerMode } from "../types";
+import type { PomodoroSettings, TimerMode, TimerState } from "../types";
 import {
   BREAK_MINUTES,
   COLOR_A_DEFAULT,
@@ -47,20 +47,14 @@ export default function DeskThingBridge() {
   // Initial settings are configured by a proactive call to the server to fetch settings data on mount:
   useEffect(() => {
     const fetchSettingsFromServer = async () => {
-      const serverData = await DeskThing.fetchData<SocketData>(
-        "initial-settings",
-        {
-          type: "get",
-          request: "initial-settings",
-        }
-      );
+      const serverData = await DeskThing.getSettings()
       let settings = DEFAULT_SETTINGS;
       if (serverData) {
         settings = coerceSettings(serverData, handleError);
       }
       handleSettings("initial", settings);
 
-      const serverState: any = await DeskThing.fetchData("server-timer-state", {
+      const serverState = await DeskThing.fetchData<TimerState>("server-timer-state", {
         type: "get",
         request: "server-timer-state",
       });

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -36,7 +36,7 @@ export default function Timer() {
 
   // Set up timer, which can be paused/unpaused based on isPaused
   useEffect(() => {
-    const timer = setInterval(() => {
+    const timer = setInterval(async () => {
       if (!p.isPaused) {
         const nextValue = p.timeLeftSec - 1;
         if (nextValue <= 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,11 @@ export type PomodoroSettings = {
   colorA: string;
   colorB: string;
 };
+
+export type TimerState = {
+  timeLeftSec: number;
+  isPaused: boolean;
+  currentMode: TimerMode;
+  currentSession: number;
+  isComplete: boolean;
+};

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,4 +1,4 @@
-import { DeskThing } from "deskthing-client";
+import { AppSettings, DeskThing } from "deskthing-client";
 import {
   PomodoroContextType,
   usePomodoroContext,
@@ -26,8 +26,14 @@ export function playNotification() {
   DeskThing.send({ type: "notify" });
 }
 
+/**
+ * Takes the AppSettings object and parses the expected settings. Throws an error if he settings are missing.
+ * @param data
+ * @param handleError 
+ * @returns 
+ */
 export function coerceSettings(
-  data: any,
+  data: AppSettings,
   handleError: (message: string) => void
 ): PomodoroSettings {
   if (!data.numSessions || !data.numSessions.value) {
@@ -60,12 +66,12 @@ export function coerceSettings(
 
   return {
     devMode: IS_DEV,
-    numSessions: data.numSessions.value,
-    sessionMinutes: data.sessionLength.value,
-    shortBreakMinutes: data.shortBreakLength.value,
-    longBreakMinutes: data.longBreakLength.value,
-    audioEnabled: data.audioEnabled.value,
-    colorA: data.colorA.value,
-    colorB: data.colorB.value,
+    numSessions: data.numSessions.value as number,
+    sessionMinutes: data.sessionLength.value as number,
+    shortBreakMinutes: data.shortBreakLength.value as number,
+    longBreakMinutes: data.longBreakLength.value as number,
+    audioEnabled: data.audioEnabled.value as boolean,
+    colorA: data.colorA.value as string,
+    colorB: data.colorB.value as string,
   };
 }


### PR DESCRIPTION
I went through and reviewed all of the code. It looks fantastic btw - just a few minor tweaks here or there 

DeskThing.getSettings does the same exact thing that your fetch() did but doesnt need to bounce off of the server to get them (uses the synced client settings - saves an unnecessary req/res)

Also, using DeskThing.addBackgroundtask() lets the task be managed by the server - i.e. cancelled or stopped or cleaned up when the user interacts with your app 


also fixed the timer logic for the backend to make it so that it would correctly calculate every second 